### PR TITLE
api: update domain for volumegroupsnapshot

### DIFF
--- a/client/apis/volumegroupsnapshot/v1beta1/doc.go
+++ b/client/apis/volumegroupsnapshot/v1beta1/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
-// +groupName=groupsnapshot.storage.k8s.io
+// +groupName=groupsnapshot.storage.openshift.io
 
 package v1beta1

--- a/client/apis/volumegroupsnapshot/v1beta1/register.go
+++ b/client/apis/volumegroupsnapshot/v1beta1/register.go
@@ -20,7 +20,7 @@ import (
 )
 
 // GroupName is the group name use in this package.
-const GroupName = "groupsnapshot.storage.k8s.io"
+const GroupName = "groupsnapshot.storage.openshift.io"
 
 var (
 	// SchemeBuilder is the new scheme builder

--- a/client/clientset/versioned/typed/volumegroupsnapshot/v1beta1/volumegroupsnapshot_client.go
+++ b/client/clientset/versioned/typed/volumegroupsnapshot/v1beta1/volumegroupsnapshot_client.go
@@ -33,7 +33,7 @@ type GroupsnapshotV1beta1Interface interface {
 	VolumeGroupSnapshotContentsGetter
 }
 
-// GroupsnapshotV1beta1Client is used to interact with features provided by the groupsnapshot.storage.k8s.io group.
+// GroupsnapshotV1beta1Client is used to interact with features provided by the groupsnapshot.storage.openshift.io group.
 type GroupsnapshotV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/client/config/crd/groupsnapshot.storage.openshift.io_volumegroupsnapshotclasses.yaml
+++ b/client/config/crd/groupsnapshot.storage.openshift.io_volumegroupsnapshotclasses.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1150"
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io
+  name: volumegroupsnapshotclasses.groupsnapshot.storage.openshift.io
 spec:
-  group: groupsnapshot.storage.k8s.io
+  group: groupsnapshot.storage.openshift.io
   names:
     kind: VolumeGroupSnapshotClass
     listKind: VolumeGroupSnapshotClassList

--- a/client/config/crd/groupsnapshot.storage.openshift.io_volumegroupsnapshotcontents.yaml
+++ b/client/config/crd/groupsnapshot.storage.openshift.io_volumegroupsnapshotcontents.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1150"
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io
+  name: volumegroupsnapshotcontents.groupsnapshot.storage.openshift.io
 spec:
-  group: groupsnapshot.storage.k8s.io
+  group: groupsnapshot.storage.openshift.io
   names:
     kind: VolumeGroupSnapshotContent
     listKind: VolumeGroupSnapshotContentList

--- a/client/config/crd/groupsnapshot.storage.openshift.io_volumegroupsnapshots.yaml
+++ b/client/config/crd/groupsnapshot.storage.openshift.io_volumegroupsnapshots.yaml
@@ -5,9 +5,9 @@ metadata:
   annotations:
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1150"
     controller-gen.kubebuilder.io/version: v0.15.0
-  name: volumegroupsnapshots.groupsnapshot.storage.k8s.io
+  name: volumegroupsnapshots.groupsnapshot.storage.openshift.io
 spec:
-  group: groupsnapshot.storage.k8s.io
+  group: groupsnapshot.storage.openshift.io
   names:
     kind: VolumeGroupSnapshot
     listKind: VolumeGroupSnapshotList

--- a/client/config/crd/kustomization.yaml
+++ b/client/config/crd/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
   - snapshot.storage.k8s.io_volumesnapshotclasses.yaml
   - snapshot.storage.k8s.io_volumesnapshotcontents.yaml
   - snapshot.storage.k8s.io_volumesnapshots.yaml
-  - groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
-  - groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
-  - groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+  - groupsnapshot.storage.openshift.io_volumegroupsnapshotclasses.yaml
+  - groupsnapshot.storage.openshift.io_volumegroupsnapshotcontents.yaml
+  - groupsnapshot.storage.openshift.io_volumegroupsnapshots.yaml

--- a/client/informers/externalversions/generic.go
+++ b/client/informers/externalversions/generic.go
@@ -53,7 +53,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=groupsnapshot.storage.k8s.io, Version=v1beta1
+	// Group=groupsnapshot.storage.openshift.io, Version=v1beta1
 	case v1beta1.SchemeGroupVersion.WithResource("volumegroupsnapshots"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Groupsnapshot().V1beta1().VolumeGroupSnapshots().Informer()}, nil
 	case v1beta1.SchemeGroupVersion.WithResource("volumegroupsnapshotclasses"):

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/doc.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
-// +groupName=groupsnapshot.storage.k8s.io
+// +groupName=groupsnapshot.storage.openshift.io
 
 package v1beta1

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/register.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1/register.go
@@ -20,7 +20,7 @@ import (
 )
 
 // GroupName is the group name use in this package.
-const GroupName = "groupsnapshot.storage.k8s.io"
+const GroupName = "groupsnapshot.storage.openshift.io"
 
 var (
 	// SchemeBuilder is the new scheme builder

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/typed/volumegroupsnapshot/v1beta1/volumegroupsnapshot_client.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/typed/volumegroupsnapshot/v1beta1/volumegroupsnapshot_client.go
@@ -33,7 +33,7 @@ type GroupsnapshotV1beta1Interface interface {
 	VolumeGroupSnapshotContentsGetter
 }
 
-// GroupsnapshotV1beta1Client is used to interact with features provided by the groupsnapshot.storage.k8s.io group.
+// GroupsnapshotV1beta1Client is used to interact with features provided by the groupsnapshot.storage.openshift.io group.
 type GroupsnapshotV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions/generic.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions/generic.go
@@ -53,7 +53,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=groupsnapshot.storage.k8s.io, Version=v1beta1
+	// Group=groupsnapshot.storage.openshift.io, Version=v1beta1
 	case v1beta1.SchemeGroupVersion.WithResource("volumegroupsnapshots"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Groupsnapshot().V1beta1().VolumeGroupSnapshots().Informer()}, nil
 	case v1beta1.SchemeGroupVersion.WithResource("volumegroupsnapshotclasses"):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

This patch updates the domain the `openshift.io` from `k8s.io` and updates the autogenerated files.

**Note:** The year update is a result of autogen. We should keep it as is to reliably check generated files by `git` in our CI.

