### PR TITLE
Enable VGS w/out feature gates for snapshotter and snapshot-controller

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -125,6 +125,9 @@ func main() {
 		klog.Fatal("Error while parsing feature gates: ", err)
 	}
 
+	// Enable VGS unconditionally
+	utilfeature.DefaultMutableFeatureGate.OverrideDefault(features.VolumeGroupSnapshot, true)
+
 	if *showVersion {
 		fmt.Println(os.Args[0], version)
 		os.Exit(0)

--- a/cmd/snapshot-controller/main.go
+++ b/cmd/snapshot-controller/main.go
@@ -172,6 +172,9 @@ func main() {
 		klog.Fatal("Error while parsing feature gates: ", err)
 	}
 
+	// Enable VGS unconditionally
+	utilfeature.DefaultMutableFeatureGate.OverrideDefault(features.VolumeGroupSnapshot, true)
+
 	if *showVersion {
 		fmt.Println(os.Args[0], version)
 		os.Exit(0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
This patch overrides the default feature gates to enable `VolumeGroupSnapshots` by default.