### PR TITLE
use private api group in unit tests

### DIFF
--- a/pkg/common-controller/framework_test.go
+++ b/pkg/common-controller/framework_test.go
@@ -1322,7 +1322,7 @@ func newGroupSnapshotContent(groupSnapshotContentName, boundToGroupSnapshotUID, 
 	if boundToGroupSnapshotName != "" {
 		content.Spec.VolumeGroupSnapshotRef = v1.ObjectReference{
 			Kind:            "VolumeGroupSnapshot",
-			APIVersion:      "groupsnapshot.storage.k8s.io/v1beta1",
+			APIVersion:      "groupsnapshot.storage.openshift.io/v1beta1",
 			UID:             types.UID(boundToGroupSnapshotUID),
 			Namespace:       testNamespace,
 			Name:            boundToGroupSnapshotName,
@@ -1492,7 +1492,7 @@ func newGroupSnapshot(
 			Namespace:         testNamespace,
 			UID:               types.UID(groupSnapshotUID),
 			ResourceVersion:   "1",
-			SelfLink:          "/apis/groupsnapshot.storage.k8s.io/v1beta1/namespaces/" + testNamespace + "/volumesnapshots/" + groupSnapshotName,
+			SelfLink:          "/apis/groupsnapshot.storage.openshift.io/v1beta1/namespaces/" + testNamespace + "/volumesnapshots/" + groupSnapshotName,
 			DeletionTimestamp: deletionTimestamp,
 		},
 		Spec: crdv1beta1.VolumeGroupSnapshotSpec{

--- a/pkg/common-controller/groupsnapshot_create_test.go
+++ b/pkg/common-controller/groupsnapshot_create_test.go
@@ -110,7 +110,7 @@ func TestCreateGroupSnapshotSync(t *testing.T) {
 					"app.kubernetes.io/name": "postgresql",
 				},
 				"", classNonExisting, "", &False, nil,
-				newVolumeError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "volumegroupsnapshotclass.groupsnapshot.storage.k8s.io \"non-existing\" not found"`),
+				newVolumeError(`failed to create group snapshot content with error failed to get input parameters to create group snapshot group-snap-1-1: "volumegroupsnapshotclass.groupsnapshot.storage.openshift.io \"non-existing\" not found"`),
 				false, false, nil,
 			),
 			initialGroupContents:  nogroupcontents,

--- a/pkg/utils/vgs_test.go
+++ b/pkg/utils/vgs_test.go
@@ -89,7 +89,7 @@ func TestIsVolumeSnapshotGroupMember(t *testing.T) {
 					Namespace: "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: "groupsnapshot.storage.k8s.io/v1beta1",
+							APIVersion: "groupsnapshot.storage.openshift.io/v1beta1",
 							Kind:       "VolumeGroupSnapshot",
 							Name:       "vgs",
 						},
@@ -191,7 +191,7 @@ func TestNeedToAddVolumeGroupSnapshotOwnership(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: "groupsnapshot.storage.k8s.io/v1beta1",
+							APIVersion: "groupsnapshot.storage.openshift.io/v1beta1",
 							Kind:       "VolumeGroupSnapshot",
 							Name:       "vgs",
 						},


### PR DESCRIPTION
use private api group in unit tests
Ref: https://github.com/red-hat-storage/external-snapshotter/actions/runs/15184759042/job/42702459801?pr=3