### PR TITLE
fix package name and registry name variable

### DIFF
--- a/.github/workflows/push-ds-image.yaml
+++ b/.github/workflows/push-ds-image.yaml
@@ -40,11 +40,11 @@ jobs:
         docker tag csi-snapshotter:latest $REGISTRY_NAME/csi-snapshotter:$IMAGE_TAG
         docker push $REGISTRY_NAME/csi-snapshotter:$IMAGE_TAG
 
-        # Build and push the snapshotter-controller image
-        make container-snapshotter-controller
-        docker tag snapshotter-controller:latest $REGISTRY_NAME/snapshotter-controller:$IMAGE_TAG
-        docker push $REGISTRY_NAME/snapshotter-controller:$IMAGE_TAG
+        # Build and push the snapshot-controller image
+        make container-snapshot-controller
+        docker tag snapshot-controller:latest $REGISTRY_NAME/snapshot-controller:$IMAGE_TAG
+        docker push $REGISTRY_NAME/snapshot-controller:$IMAGE_TAG
 
-        # Build and push the snapshotter-controller-bundle image
+        # Build and push the snapshot-controller-bundle image
         make -f Makefile.Downstream.mk bundle-build
         make -f Makefile.Downstream.mk bundle-push

--- a/Makefile.Downstream.mk
+++ b/Makefile.Downstream.mk
@@ -1,12 +1,11 @@
 # defining variables here before including "Makefile" makes these variables unique for current makefile
-IMAGE_REGISTRY ?= quay.io
-REGISTRY_NAME ?= ocs-dev
+REGISTRY_NAME ?= quay.io/ocs-dev
 IMAGE_TAG ?= latest
 IMAGE_NAME ?= snapshot-controller
 
 BUNDLE_IMAGE_NAME ?= $(IMAGE_NAME)-bundle
 
-BUNDLE_IMG ?= $(IMAGE_REGISTRY)/$(REGISTRY_NAME)/$(BUNDLE_IMAGE_NAME):$(IMAGE_TAG)
+BUNDLE_IMG ?= $(REGISTRY_NAME)/$(BUNDLE_IMAGE_NAME):$(IMAGE_TAG)
 
 # the PACKAGE_NAME is included in the bundle/CSV and is used in catalogsources
 # for operators (like OperatorHub.io). Products that include the ceph-csi-operator


### PR DESCRIPTION
Dix package name in github action.
Update registry_name variable to contain both image_registry and registry_name to keep in-line with other make commands.
