### PR TITLE
sidecar: Use different prefix for leader election

### DIFF
--- a/cmd/csi-snapshotter/main.go
+++ b/cmd/csi-snapshotter/main.go
@@ -104,7 +104,7 @@ var (
 
 var (
 	version = "unknown"
-	prefix  = "external-snapshotter-leader"
+	prefix  = "odf-external-snapshotter-leader"
 )
 
 func main() {


### PR DESCRIPTION
This patch changes the prefix for sidecar leader election.