### PR TITLE
Enable snapshot controller and sidecar for ODF managed VolumeSnapshots

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -566,6 +566,7 @@ func (ctrl *csiSnapshotCommonController) createSnapshotsForGroupSnapshotContent(
 				Name: volumeSnapshotContentName,
 				Annotations: map[string]string{
 					utils.VolumeGroupSnapshotHandleAnnotation: *groupSnapshotContent.Status.VolumeGroupSnapshotHandle,
+					utils.AnnODFManagedSnapResource:           "true",
 				},
 			},
 			Spec: crdv1.VolumeSnapshotContentSpec{
@@ -604,6 +605,9 @@ func (ctrl *csiSnapshotCommonController) createSnapshotsForGroupSnapshotContent(
 					utils.BuildVolumeGroupSnapshotOwnerReference(groupSnapshot),
 				},
 				Finalizers: []string{utils.VolumeSnapshotInGroupFinalizer},
+				Annotations: map[string]string{
+					utils.AnnODFManagedSnapResource: "true",
+				},
 			},
 			// The spec stanza is set immediately
 			// The status will be set by VolumeSnapshot reconciler

--- a/pkg/common-controller/snapshot_controller_base.go
+++ b/pkg/common-controller/snapshot_controller_base.go
@@ -277,8 +277,8 @@ func (ctrl *csiSnapshotCommonController) Run(workers int, stopCh <-chan struct{}
 	ctrl.initializeCaches()
 
 	for i := 0; i < workers; i++ {
-		// go wait.Until(ctrl.snapshotWorker, 0, stopCh)
-		// go wait.Until(ctrl.contentWorker, 0, stopCh)
+		go wait.Until(ctrl.snapshotWorker, 0, stopCh)
+		go wait.Until(ctrl.contentWorker, 0, stopCh)
 		if ctrl.enableVolumeGroupSnapshots {
 			go wait.Until(ctrl.groupSnapshotWorker, 0, stopCh)
 			go wait.Until(ctrl.groupSnapshotContentWorker, 0, stopCh)
@@ -355,6 +355,11 @@ func (ctrl *csiSnapshotCommonController) syncSnapshotByKey(key string) error {
 	}
 	snapshot, err := ctrl.snapshotLister.VolumeSnapshots(namespace).Get(name)
 	if err == nil {
+		if _, e := snapshot.GetAnnotations()[utils.AnnODFManagedSnapResource]; !e {
+			klog.Infof("%s is not a volumesnapshot managed by ODF, doing nothing for it.", snapshot.GetName())
+
+			return nil
+		}
 		// The volume snapshot still exists in informer cache, the event must have
 		// been add/update/sync
 		newSnapshot, err := ctrl.checkAndUpdateSnapshotClass(snapshot)
@@ -431,6 +436,11 @@ func (ctrl *csiSnapshotCommonController) syncContentByKey(key string) error {
 	// The content still exists in informer cache, the event must have
 	// been add/update/sync
 	if err == nil {
+		if _, e := content.GetAnnotations()[utils.AnnODFManagedSnapResource]; !e {
+			klog.Infof("%s is not a volumesnapshotcontent managed by ODF, doing nothing for it.", content.GetName())
+
+			return nil
+		}
 		// If error occurs we add this item back to the queue
 		return ctrl.updateContent(content)
 	}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -156,6 +156,8 @@ const (
 	// VolumeSnapshotContentManagedByLabel is applied by the snapshot controller to the VolumeSnapshotContent object in case distributed snapshotting is enabled.
 	// The value contains the name of the node that handles the snapshot for the volume local to that node.
 	VolumeSnapshotContentManagedByLabel = "snapshot.storage.kubernetes.io/managed-by"
+
+	AnnODFManagedSnapResource = "storage.openshift.io/odf-managed"
 )
 
 var SnapshotterSecretParams = secretParamsMap{


### PR DESCRIPTION
This patch enables the reconcile of `VolumeSnapshot` and `VolumeSnapshotContents` for the resources that are created as a part of a VGS and are managed by ODF.

The watchers ignore the resources that do not have `AnnODFManagedSnapResource` set in their annotations and hence delegate the processing of such resources to the upstream snapshotter.

