### PR TITLE
snapshot-controller: Skip unmanaged `VolumeSnapshot*` in cache

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -719,3 +719,10 @@ func ShouldEnqueueContentChange(old *crdv1.VolumeSnapshotContent, new *crdv1.Vol
 	}
 	return true
 }
+
+// IsODFManagedResource checks if the resource is managed and should be handled by ODF
+func IsODFManagedResource(obj metav1.Object) bool {
+	_, ok := obj.GetAnnotations()[AnnODFManagedSnapResource]
+
+	return ok
+}


### PR DESCRIPTION
This patch adds the functionality to skip VolumeSnapshots that are not present on the cluster by may be found in the cache awaiting eviction.

Earlier the check for ODF managed resource was only done when the object was found in the cluster. We should not be processing any VolumeSnapshots as they are to be handled by upstream snapshotter.