### PR TITLE
common-controller: Fix nil pointer deref

### DIFF
--- a/pkg/common-controller/snapshot_controller_base.go
+++ b/pkg/common-controller/snapshot_controller_base.go
@@ -321,8 +321,12 @@ func (ctrl *csiSnapshotCommonController) enqueueContentWork(obj interface{}) {
 			klog.Errorf("failed to get key from object: %v, %v", err, content)
 			return
 		}
-		klog.V(5).Infof("enqueued %q for sync", objName)
-		ctrl.contentQueue.Add(objName)
+		if utils.IsODFManagedResource(content) {
+			klog.V(5).Infof("enqueued %q for sync", objName)
+			ctrl.contentQueue.Add(objName)
+		} else {
+			klog.V(5).Infof("%s is not a volumesnapshotcontent managed by ODF, doing nothing for it.", objName)
+		}
 	}
 }
 


### PR DESCRIPTION
The snapshot contents that are not supposed to be reconciled by our snapshotter were incorrectly added to the work queue.

Which led to runtime panic when deleting the snapshot content.

This patch fixes the above issue by adding snapshot content to queue only when the resource is to be managed by us.

