### PR TITLE
add requests and limits to snapshot-controller

### DIFF
--- a/bundle/manifests/odf-external-snapshotter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-external-snapshotter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2025-06-11T08:23:07Z"
+    createdAt: "2025-09-25T14:28:43Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -168,7 +168,13 @@ spec:
                 image: quay.io/ocs-dev/snapshot-controller:latest
                 imagePullPolicy: IfNotPresent
                 name: odf-external-snapshotter-operator
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 50Mi
               serviceAccountName: odf-external-snapshotter-operator
       permissions:
       - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,3 +35,10 @@ spec:
             # For example, in https://github.com/kubernetes-csi/csi-release-tools/pull/209, the snapshot-controller YAML is updated to add --prevent-volume-mode-conversion=true so that the feature can be enabled for certain e2e tests.
             # end snapshot controller args
           imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi


### PR DESCRIPTION
add requests and limits to snapshot-controller deployment based on the values set by openshift for the snapshot-controller.
Ref: https://issues.redhat.com/browse/RHSTOR-6148