### PR TITLE
common-controller: fix stale `VolumeGroupSnapshotHandle` in `VolumeSnapshotContent`

### DIFF
--- a/pkg/common-controller/groupsnapshot_controller_helper.go
+++ b/pkg/common-controller/groupsnapshot_controller_helper.go
@@ -623,7 +623,7 @@ func (ctrl *csiSnapshotCommonController) createSnapshotsForGroupSnapshotContent(
 			volumeSnapshot.Spec.Source.PersistentVolumeClaimName = &emptyString
 		}
 
-		createdVolumeSnapshotContent, err := ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Create(ctx, volumeSnapshotContent, metav1.CreateOptions{})
+		_, err = ctrl.clientset.SnapshotV1().VolumeSnapshotContents().Create(ctx, volumeSnapshotContent, metav1.CreateOptions{})
 		if err != nil && !apierrs.IsAlreadyExists(err) {
 			return groupSnapshotContent, fmt.Errorf(
 				"createSnapshotsForGroupSnapshotContent: creating volumesnapshotcontent %w", err)
@@ -683,7 +683,7 @@ func (ctrl *csiSnapshotCommonController) createSnapshotsForGroupSnapshotContent(
 		// set the snapshot handle and the group snapshot handle
 		// inside the volume snapshot content to allow
 		// the CSI Snapshotter sidecar to reconcile its status
-		_, err = utils.PatchVolumeSnapshotContent(createdVolumeSnapshotContent, []utils.PatchOp{
+		_, err = utils.PatchVolumeSnapshotContent(volumeSnapshotContent, []utils.PatchOp{
 			{
 				Op:    "replace",
 				Path:  "/status",


### PR DESCRIPTION
This patch fixes an issue where the `VolumeSnapshot` would end up in a reconcile loop due to the controller not being able to find the `VolumeGroupSnapshot` that was set in the `VolumeSnapshotContent`'s status for a `VolumeSnapshot`.

The issue arose from a logic error which led to the `VolumeSnapshotContent.Status.VolumeGroupSnapshotHandle` never being updated except for the first/initial creation.

More specifically, the resource being passed to patch was empty in the cases where `VolumeSnapshotContent` already existed on the cluster.

This patch passes the correct name to patch function to fix the issue.

Note to reviewer: The `PatchVolumeSnapshotContent` only reads `ObjectMeta.Name`so there is no need to fetch the existing `VolumeSnapshotContent` from the API server.

