### PR TITLE
bundle: inject `priorityClassName` to generated bundle

### DIFF
--- a/bundle/manifests/odf-external-snapshotter-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/odf-external-snapshotter-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    createdAt: "2026-01-27T14:03:20Z"
+    createdAt: "2026-01-30T10:12:41Z"
     olm.skipRange: ""
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/operator-type: non-standalone
@@ -175,6 +175,7 @@ spec:
                   requests:
                     cpu: 10m
                     memory: 50Mi
+              priorityClassName: system-cluster-critical
               serviceAccountName: odf-external-snapshotter-operator
               tolerations:
               - effect: NoSchedule

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -3,3 +3,18 @@
 # used to generate the 'manifests/' directory in a bundle.
 resources:
   - ../default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+# Inject a `priorityClassName` into the controller Deployment so that the pod
+# is scheduled with higher (or lower) priority during cluster resource
+# contention.
+#
+# The default value is `system-cluster-critical`, to change that:
+#   1. Edit `manager_priority_patch.yaml`
+#   2. Set the desired `priorityClassName`
+#
+# Reference:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption
+#
+- path: manager_priority_patch.yaml

--- a/config/manifests/manager_priority_patch.yaml
+++ b/config/manifests/manager_priority_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odf-external-snapshotter-operator
+  namespace: openshift-storage
+spec:
+  template:
+    spec:
+      priorityClassName: system-cluster-critical


### PR DESCRIPTION
Inject `system-cluster-critical` as `priorityClassName` in the generated bundle.