### PR TITLE
ci: Update trivy go version to 1.25.5

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.11
+          go-version: 1.25
 
       - name: Build images from Dockerfile
         run: |


### PR DESCRIPTION
This patch updates the go version for trivy to 1.25.5
